### PR TITLE
setup remote container development for VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+// reference: https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference
+// reference: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/alpine-3.10-git/.devcontainer/devcontainer.json
+
+{
+	"name": "SWEEP Development Environment",
+	"dockerFile": "dockerfile",
+	"remoteUser": "vscode",
+	"settings":
+	{
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"postCreateCommand": ""
+	// An array of Docker CLI arguments that should be used when running the container.
+	"runArgs": []
+}

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,30 @@
+# reference: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/alpine-3.10-git/.devcontainer/Dockerfile
+
+FROM alpine:3.10
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# need the musl-dev library to get stdio, etc to work
+# alpine uses musl not glibc
+RUN apk add --no-cache bash make gcc musl-dev git tmux vim \
+	#
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && addgroup -g $USER_GID $USERNAME \
+    && adduser -S -s /bin/bash -u $USER_UID -G $USERNAME $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apk add --no-cache sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+#RUN mkdir sweep
+#COPY . sweep
+#ENTRYPOINT ["/bin/sh"]
+
+# notes
+# - bash was not included in the image, contrary to what the alpine sample indicated

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -22,9 +22,5 @@ RUN apk add --no-cache bash make gcc musl-dev git tmux vim \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-#RUN mkdir sweep
-#COPY . sweep
-#ENTRYPOINT ["/bin/sh"]
-
 # notes
 # - bash was not included in the image, contrary to what the alpine sample indicated

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -21,6 +21,8 @@ RUN apk add --no-cache bash make gcc musl-dev git tmux vim \
     && apk add --no-cache sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME
+    # add /sweep directory for non-VSCode develoment
+    && mkdir -p /sweep
 
 # notes
 # - bash was not included in the image, contrary to what the alpine sample indicated

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,19 @@
-# setting up the dev environment
+# developing with containers
 
-## build the docker container
+## using visual studio code
+
+Install the `Remote - Containers` extension for VS Code.
+
+Open the `sweep` folder in VS Code and it will autodetect the settings and ask to relaunch the window with container support.
+
+## using the command line
+
+### build the docker container
+
+The dockerfile is in the .devcontainer folder
 
 `docker build --tag sweep/shell shell`
 
-## launch the container 
+### launch the container 
 
 `docker run -it -v ${pwd}:/sweep sweep/shell`

--- a/shell/dockerfile
+++ b/shell/dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.7
-# need the musl-dev library to get stido, etc to work
-# alpine uses musl not glibc
-RUN apk add --no-cache make gcc musl-dev git tmux vim
-RUN mkdir sweep
-COPY . sweep
-ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Migrated the manual containerized development environment to get basic VS Code support.  

Staying with Alpine Linux for now, even through support is in preview, because that is what I was using before.

References
- [remote development in containers: getting started](https://code.visualstudio.com/remote-tutorials/containers/getting-started)
- [developing inside a container](https://code.visualstudio.com/docs/remote/containers)
- [basic alpine devcontainer setup](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/alpine-3.10-git)