### PR TITLE
Cant read sgd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/gen_probe
 src/probe.dat
 src/probes.c
 sweep
+sweep-tests
 
 # C intermediary files
 *.o

--- a/journal/20200103.md
+++ b/journal/20200103.md
@@ -1,0 +1,18 @@
+20200103
+
+better late than never.
+
+fixing the issue where the windows end of line messes up SWEEP reading files.  
+the extra characters as the end result in a file not found.
+
+so i decided that instead of fixing the clear_nls() function which iterated over a collection of strings, i'd write a trim function.
+
+so while i wanted to trim in-place, i didn't want to deal with the copy-left for trimming the left of the string.  thus i decided to pass in a separate buffer.  but now things are getting more complicated than i wanted, plus i'm trying to figure out how i want to add unit testing to all this and TDD my way through.
+
+but riding in the car to mom's house led to the realization that i only need the right-trim right now.  sure, i should have the left trim too, but let's be iterative.
+
+and the simple right trim starts seg faulting...hello gdb.  not obvious.  everything seems correct.  then it hits me.
+
+the problem is that `char* input = "spaceman\n"` can't be modified...segfault.
+
+change it to `char input[] = "spaceman\n"` and progress continues.

--- a/journal/20200104.md
+++ b/journal/20200104.md
@@ -1,0 +1,9 @@
+20200104
+
+not much time today.
+
+trying to just replace the call to clear_nls()
+
+the swap was pretty easy.  there are more things to fix, but this closes the SGD file issue.
+
+makefiles are fun.  adding string-util.c was causing an odd make error.  so i removed it from the list of sources...got the previous error.  added it to a different spot...everything worked correctly.  put it back to where i initially had it...it worked as expected.  this is the good life.

--- a/makefile
+++ b/makefile
@@ -4,10 +4,11 @@ SRC_DIR = src
 
 #all: sweep test
 
-all-follow:
-	$(MAKE) --directory=src V=all_follow
+all-follow: build-all-follow
 	./sweep exp/all_follow.exp 1234
 
+build-all-follow:
+	$(MAKE) --directory=src V=all_follow
 
 
 

--- a/src/file.c
+++ b/src/file.c
@@ -1,12 +1,12 @@
 /* Contains all functions and structs dealing with files */
 
-# include <string.h>
-# include <stdlib.h>
+#include <string.h>
+#include <stdlib.h>
 #include <stdio.h>
 
-# include "errors.h"
+#include "errors.h"
 #include "trace.h"
-# include "constants.h"
+#include "constants.h"
 
 extern char* FSA_FILE_NAME;
 extern char* AGENT_FILE_NAME;

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,9 @@ struct ConfigurationFiles* ReadConfigurationFromFile(const char* configurationFi
     fclose( FILE_NAME_FILE );
     
     clear_nls( file_names, 5 );
+        
+        replaced clear_nls() with trim_right_inplace()
+
     assign_fptrs( file_names, 0, 5 );
    */
     return NULL;

--- a/src/makefile
+++ b/src/makefile
@@ -3,6 +3,8 @@ SHELL = /bin/sh
 all:
 	$(if $(V), $(MAKE) -f makefile_user V=$(V) ; $(MAKE) -f makefile_system all,$(error Usage: make V=<experiment name>))
 
+tests:
+
 new: main
 
 allclean: clean

--- a/src/makefile-tests
+++ b/src/makefile-tests
@@ -1,0 +1,15 @@
+include makefile_common
+
+SOURCES = \
+    tests.c \
+    string-util.c \
+    tests-string-util.c
+
+OBJECTS = $(SOURCES:.c=.o)
+
+include $(SOURCES:.c=.d)
+
+tests: $(OBJECTS)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o ../sweep-tests
+
+include makefile_common

--- a/src/makefile_common
+++ b/src/makefile_common
@@ -4,9 +4,6 @@ CC = gcc
 CFLAGS =  -g -Wall -I.
 LDFLAGS =  -L. -lm
 
-objdir = ../obj
-#includedir = ../include
-
 # the .d files are dependency files
 # gcc is used to figure out source file dependencies automagically
 %.d: %.c

--- a/src/makefile_system
+++ b/src/makefile_system
@@ -17,6 +17,7 @@ SOURCES = 	\
 		swarm.c \
 		sweep.c \
 		trace.c \
+		string-util.c \
 		update_support.c 
 
 EXPERIMENT_DIR = ../exps

--- a/src/string-util.c
+++ b/src/string-util.c
@@ -1,0 +1,12 @@
+#include <ctype.h>
+#include <string.h>
+
+#include "string-util.h"
+
+void trim_right_inplace( char* str )
+{
+    size_t length = strlen(str);
+    char* end = str+length-1;
+    while(isspace(*end)) { end--; }
+    *(end+1) = '\0';
+}

--- a/src/string-util.h
+++ b/src/string-util.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// removes whitespace from the beginning and end of a null-terminated string
+void trim_right_inplace( char* str );

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "trace.h"
+#include "string-util.h"
 
 #include "useful.h"
 #include "file.h"
@@ -109,7 +110,11 @@ int main ( int argc, char *argv[] )
 
 			fclose( FILE_NAME_FILE );
 
-			clear_nls( file_names, 5 );
+			for( int x = 0; x < 5; x++ )
+			{
+				trim_right_inplace(file_names[x]);
+			}
+
 			assign_fptrs( file_names, 0, 5 );
 
 			/* Build up the name of each file from given name */

--- a/src/tests-string-util.c
+++ b/src/tests-string-util.c
@@ -1,0 +1,30 @@
+#include <string.h>
+#include <assert.h>
+
+#include <stdio.h>
+
+#include "string-util.h"
+
+void test_trim_right_inplace_NoModification()
+{
+    char actual[] = "spaceman";
+    const char* expected = "spaceman";
+    trim_right_inplace(actual);
+    int result = strncmp(actual, expected, strlen(actual));
+    assert(result == 0 && "the string was not trimmed correctly");
+}
+
+void test_trim_right_inplace_WhitespaceAtEnd()
+{
+    char actual[] = "spaceman \t\n";
+    const char* expected = "spaceman";
+    trim_right_inplace(actual);
+    int result = strncmp(actual, expected, strlen(actual));
+    assert(result == 0 && "the string was not trimmed correctly");
+}
+
+void run_string_util_tests()
+{
+    test_trim_right_inplace_NoModification();
+    test_trim_right_inplace_WhitespaceAtEnd();
+}

--- a/src/tests.c
+++ b/src/tests.c
@@ -1,0 +1,9 @@
+// prototyping test methods here for now.
+// consider separate header files later
+
+void run_string_util_tests();
+
+int main()
+{
+    run_string_util_tests();
+}


### PR DESCRIPTION
The issue (#8 ) with the SGD file (and other files) was the extra linefeed that showed up in the strings when the files were bounced Windows, Linux, and Git.

The existing code only stripped out '\n' because the code was initially written to only be run in Linux.  

The solution was to create a better right trim function.